### PR TITLE
Add advice's to delete-frames after po-subedit in po-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .cask
 flycheck_frames-only-mode.el
+*.elc
+*autoloads.el


### PR DESCRIPTION
When using `popup-frames` a new frame is spawned each time
the user selects a text to translate but the frame doesn't
close when done.