### PR TITLE
Fix corfu-popupinfo-mode

### DIFF
--- a/frames-only-mode.el
+++ b/frames-only-mode.el
@@ -54,7 +54,7 @@ To disable completion popups entirely use the variable
   :group 'frames-only)
 
 (defcustom frames-only-mode-use-window-functions
-  (list #'calendar #'report-emacs-bug 'checkdoc-show-diagnostics 'checkdoc 'org-compile-file)
+  (list #'calendar #'report-emacs-bug 'checkdoc-show-diagnostics 'checkdoc 'org-compile-file 'corfu-popupinfo--show)
   "List of functions inside which new emacs windows should be
 created instead of frames.
 


### PR DESCRIPTION
By default, `corfu-popupinfo-mode`'s popup window appears as a new frame rather than a proper popup. Adding `corfu-popupinfo--show` to the list of functions to ignore seems to fix the issue.

Not sure if this is the best way to solve it, or if `frames-only-mode-use-window-functions` is intended to have broad defaults, so feel free to close this PR if functions like these should be left to user configuration.